### PR TITLE
fix: doubled slashes when parentheses in links

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,9 +27,9 @@ function escapeSymbols(text, textType = 'text') {
 				.replace(/\\/g, '\\\\')
 		case 'link':
 			return text
+				.replace(/\\/g, '\\\\')
 				.replace(/\(/g, '\\(')
 				.replace(/\)/g, '\\)')
-				.replace(/\\/g, '\\\\')
 		default:
 			return text
 				.replace(/_/g, '\\_')

--- a/tests/convert.spec.js
+++ b/tests/convert.spec.js
@@ -119,6 +119,13 @@ describe('Test convert method', () => {
 		expect(convert(markdown)).toBe(tgMarkdown);
 	});
 
+	it('Link in reference style with parentheses', () => {
+		const markdown = '[Atlassian](http://atlas()sian.com)';
+		const tgMarkdown = '[Atlassian](http://atlas\\(\\)sian.com)\n';
+		expect(convert(markdown)).toBe(tgMarkdown);
+	});
+
+
 	it('Image with title', () => {
 		const markdown = '![](https://bitbucket.org/repo/123/images/logo.png "test")';
 		const tgMarkdown = '[test](https://bitbucket.org/repo/123/images/logo.png)\n';

--- a/tests/convert.spec.js
+++ b/tests/convert.spec.js
@@ -89,6 +89,12 @@ describe('Test convert method', () => {
 		expect(convert(markdown)).toBe(tgMarkdown);
 	});
 
+	it('Link with parentheses', () => {
+		const markdown = '[Atlassian](http://atlas()sian.com)';
+		const tgMarkdown = '[Atlassian](http://atlas\\(\\)sian.com)\n';
+		expect(convert(markdown)).toBe(tgMarkdown);
+	});
+
 	it('Link in reference style with alt', () => {
 		const markdown = '[Atlassian]\n\n[atlassian]: http://atlassian.com';
 		const tgMarkdown = '[Atlassian](http://atlassian.com)\n';
@@ -118,13 +124,6 @@ describe('Test convert method', () => {
 		const tgMarkdown = 'Atlassian\n';
 		expect(convert(markdown)).toBe(tgMarkdown);
 	});
-
-	it('Link in reference style with parentheses', () => {
-		const markdown = '[Atlassian](http://atlas()sian.com)';
-		const tgMarkdown = '[Atlassian](http://atlas\\(\\)sian.com)\n';
-		expect(convert(markdown)).toBe(tgMarkdown);
-	});
-
 
 	it('Image with title', () => {
 		const markdown = '![](https://bitbucket.org/repo/123/images/logo.png "test")';


### PR DESCRIPTION
## Description
Library doubles escape characters in url links that contain parentheses.

`http://atlassian().com` currently is transformed into `http://atlassian\\(\\).com`.
The correct output should be `http://atlassian\(\).com`.

## Additional Notes
- The changes have been thoroughly tested locally and passed all existing test cases.
- Please review and provide feedback. Thank you!
