### PR TITLE
fix: prevent from encoding already encoded url links

### DIFF
--- a/lib/telegramify.js
+++ b/lib/telegramify.js
@@ -70,7 +70,8 @@ const createHandlers = (definitions, unsupportedTagsStrategy) => ({
 	link: (node, _parent, context) => {
 		const exit = context.enter('link');
 		const text = phrasing(node, context, {before: '|', after: '>'}) || escapeSymbols(node.title);
-		const url = encodeURI(node.url);
+		const isUrlEncoded = decodeURI(node.url) !== node.url;
+		const url = isUrlEncoded ? node.url : encodeURI(node.url);
 		exit();
 
 		if (!isURL(url)) return escapeSymbols(text) || escapeSymbols(url);

--- a/tests/convert.spec.js
+++ b/tests/convert.spec.js
@@ -89,6 +89,12 @@ describe('Test convert method', () => {
 		expect(convert(markdown)).toBe(tgMarkdown);
 	});
 
+	it('Link that is already encoded', () => {
+		const markdown = '[Atlassian](http://atlassian.com?s=%7B0622CBE5)';
+		const tgMarkdown = '[Atlassian](http://atlassian.com?s=%7B0622CBE5)\n';
+		expect(convert(markdown)).toBe(tgMarkdown);
+	});
+
 	it('Link in reference style with alt', () => {
 		const markdown = '[Atlassian]\n\n[atlassian]: http://atlassian.com';
 		const tgMarkdown = '[Atlassian](http://atlassian.com)\n';


### PR DESCRIPTION
## Description
This pull request addresses handling links that are already encoded.

Currently, `[Atlassian](http://atlassian.com?s=%7B0622CBE5)` is transformed to `[Atlassian](http://atlassian.com?s=%257B0622CBE5)`.

The correct result should be: `[Atlassian](http://atlassian.com?s=%7B0622CBE5)`

## Additional Notes
- The changes have been tested locally to ensure compatibility with existing functionality.
- Please review and provide feedback. Thank you!