### PR TITLE
Fix malformed typescript exports

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-export type UnsupportedTagsStrategy = 'escape' | 'remove' | 'keep'
+type UnsupportedTagsStrategy = 'escape' | 'remove' | 'keep'
 
 declare module 'telegramify-markdown' {
 


### PR DESCRIPTION
When using your module as a `ES` module like this
```ts
import telegramifyMarkdown from 'telegramify-markdown'
```
the following compile error occurs:
```
node_modules/telegramify-markdown/types/index.d.ts(12,3): 
error TS2666: 
Exports and export assignments are not permitted in module augmentations.
```
The issue is explained [here](https://stackoverflow.com/a/48708568) 
and it basically says you can't use `export =` and `export`  together in one module
because it mixes up `commonjs` module and `ES` module syntax.

I found the simple fix is removing the export on `UnsupportedTagsStrategy`,
because the module will simply continue to work as is.
The autocompletion on the second parameter of `convert` also continues to work.

While at it you can add to your README somewhere that 
```ts
import telegramifyMarkdown from 'telegramify-markdown'
```
is the `ES` module compatible import.