### PR TITLE
feat: add table handler

### DIFF
--- a/lib/telegramify.js
+++ b/lib/telegramify.js
@@ -1,5 +1,6 @@
 const defaultHandlers = require('mdast-util-to-markdown/lib/handle');
 const phrasing = require('mdast-util-to-markdown/lib/util/container-phrasing');
+const {toMarkdown: gfmTableToMarkdown} = require('mdast-util-gfm-table')
 
 const {wrap, isURL, escapeSymbols, processUnsupportedTags} = require('./utils');
 
@@ -132,6 +133,8 @@ const createHandlers = (definitions, unsupportedTagsStrategy) => ({
 		processUnsupportedTags(defaultHandlers.blockquote(node, _parent, context), unsupportedTagsStrategy),
 	html: (node, _parent, context) =>
 		processUnsupportedTags(defaultHandlers.html(node, _parent, context), unsupportedTagsStrategy),
+	table: (node, _parent, context) =>
+		processUnsupportedTags(gfmTableToMarkdown().handlers.table(node, _parent, context), unsupportedTagsStrategy),
 });
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"mdast-util-gfm-table": "^1.0.6",
+				"mdast-util-gfm-table": "^0.1.6",
 				"mdast-util-to-markdown": "^0.6.2",
 				"remark-gfm": "^1.0.0",
 				"remark-parse": "^9.0.0",
@@ -1724,14 +1724,6 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
-		"node_modules/@types/debug": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-			"integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-			"dependencies": {
-				"@types/ms": "*"
-			}
-		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1778,11 +1770,6 @@
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
 			"integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
 			"dev": true
-		},
-		"node_modules/@types/ms": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
 		},
 		"node_modules/@types/node": {
 			"version": "18.11.18",
@@ -2748,27 +2735,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/decode-named-character-reference": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-			"integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-			"dependencies": {
-				"character-entities": "^2.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/decode-named-character-reference/node_modules/character-entities": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -2827,14 +2793,6 @@
 			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
 			"dev": true
 		},
-		"node_modules/dequal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2842,14 +2800,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/diff": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-			"integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/diff-sequences": {
@@ -5492,9 +5442,13 @@
 			}
 		},
 		"node_modules/markdown-table": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-			"integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+			"integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+			"license": "MIT",
+			"dependencies": {
+				"repeat-string": "^1.0.0"
+			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
@@ -5602,175 +5556,12 @@
 			}
 		},
 		"node_modules/mdast-util-gfm-table": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.6.tgz",
-			"integrity": "sha512-uHR+fqFq3IvB3Rd4+kzXW8dmpxUhvgCQZep6KdjsLK4O6meK5dYZEayLtIxNus1XO3gfjfcIFe8a7L0HZRGgag==",
-			"dependencies": {
-				"@types/mdast": "^3.0.0",
-				"markdown-table": "^3.0.0",
-				"mdast-util-from-markdown": "^1.0.0",
-				"mdast-util-to-markdown": "^1.3.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/longest-streak": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/mdast-util-from-markdown": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
-			"integrity": "sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==",
-			"dependencies": {
-				"@types/mdast": "^3.0.0",
-				"@types/unist": "^2.0.0",
-				"decode-named-character-reference": "^1.0.0",
-				"mdast-util-to-string": "^3.1.0",
-				"micromark": "^3.0.0",
-				"micromark-util-decode-numeric-character-reference": "^1.0.0",
-				"micromark-util-decode-string": "^1.0.0",
-				"micromark-util-normalize-identifier": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0",
-				"unist-util-stringify-position": "^3.0.0",
-				"uvu": "^0.5.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/mdast-util-to-markdown": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.4.0.tgz",
-			"integrity": "sha512-IjXARf/O8VGx/pc5SZ7syfydq1DYL9vd92orsG5U0b4GNCmAvXzu+n7sbzfIKrXwB0AVrYk3NV2kXl0AIi9LCA==",
-			"dependencies": {
-				"@types/mdast": "^3.0.0",
-				"@types/unist": "^2.0.0",
-				"longest-streak": "^3.0.0",
-				"mdast-util-to-string": "^3.0.0",
-				"micromark-util-decode-string": "^1.0.0",
-				"unist-util-visit": "^4.0.0",
-				"zwitch": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/mdast-util-to-string": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
-			"integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/micromark": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz",
-			"integrity": "sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"@types/debug": "^4.0.0",
-				"debug": "^4.0.0",
-				"decode-named-character-reference": "^1.0.0",
-				"micromark-core-commonmark": "^1.0.1",
-				"micromark-factory-space": "^1.0.0",
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-chunked": "^1.0.0",
-				"micromark-util-combine-extensions": "^1.0.0",
-				"micromark-util-decode-numeric-character-reference": "^1.0.0",
-				"micromark-util-encode": "^1.0.0",
-				"micromark-util-normalize-identifier": "^1.0.0",
-				"micromark-util-resolve-all": "^1.0.0",
-				"micromark-util-sanitize-uri": "^1.0.0",
-				"micromark-util-subtokenize": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.1",
-				"uvu": "^0.5.0"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/unist-util-is": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
-			"integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/unist-util-stringify-position": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
-			"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
-			"dependencies": {
-				"@types/unist": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/unist-util-visit": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.1.tgz",
-			"integrity": "sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^5.0.0",
-				"unist-util-visit-parents": "^5.1.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/unist-util-visit-parents": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.1.tgz",
-			"integrity": "sha512-gks4baapT/kNRaWxuGkl5BIhoanZo7sC/cUT/JToSRNL1dYoXRFl75d++NkjYk4TAu2uv2Px+l8guMajogeuiw==",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^5.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-table/node_modules/zwitch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/mdast-util-gfm-task-list-item": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
-			"integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+			"integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+			"license": "MIT",
 			"dependencies": {
+				"markdown-table": "^2.0.0",
 				"mdast-util-to-markdown": "~0.6.0"
 			},
 			"funding": {
@@ -5778,24 +5569,11 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-gfm/node_modules/markdown-table": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-			"integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-			"dependencies": {
-				"repeat-string": "^1.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/mdast-util-gfm/node_modules/mdast-util-gfm-table": {
+		"node_modules/mdast-util-gfm-task-list-item": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
-			"integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+			"integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
 			"dependencies": {
-				"markdown-table": "^2.0.0",
 				"mdast-util-to-markdown": "~0.6.0"
 			},
 			"funding": {
@@ -5888,39 +5666,6 @@
 				"parse-entities": "^2.0.0"
 			}
 		},
-		"node_modules/micromark-core-commonmark": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz",
-			"integrity": "sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"decode-named-character-reference": "^1.0.0",
-				"micromark-factory-destination": "^1.0.0",
-				"micromark-factory-label": "^1.0.0",
-				"micromark-factory-space": "^1.0.0",
-				"micromark-factory-title": "^1.0.0",
-				"micromark-factory-whitespace": "^1.0.0",
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-chunked": "^1.0.0",
-				"micromark-util-classify-character": "^1.0.0",
-				"micromark-util-html-tag-name": "^1.0.0",
-				"micromark-util-normalize-identifier": "^1.0.0",
-				"micromark-util-resolve-all": "^1.0.0",
-				"micromark-util-subtokenize": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.1",
-				"uvu": "^0.5.0"
-			}
-		},
 		"node_modules/micromark-extension-gfm": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
@@ -5994,361 +5739,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
-		},
-		"node_modules/micromark-factory-destination": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
-			"integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-factory-label": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
-			"integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0",
-				"uvu": "^0.5.0"
-			}
-		},
-		"node_modules/micromark-factory-space": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
-			"integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-factory-title": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
-			"integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-factory-space": "^1.0.0",
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0",
-				"uvu": "^0.5.0"
-			}
-		},
-		"node_modules/micromark-factory-whitespace": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
-			"integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-factory-space": "^1.0.0",
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-character": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
-			"integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-chunked": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
-			"integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-classify-character": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
-			"integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-combine-extensions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
-			"integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-chunked": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-decode-numeric-character-reference": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
-			"integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-decode-string": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
-			"integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"decode-named-character-reference": "^1.0.0",
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-decode-numeric-character-reference": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-encode": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
-			"integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			]
-		},
-		"node_modules/micromark-util-html-tag-name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz",
-			"integrity": "sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			]
-		},
-		"node_modules/micromark-util-normalize-identifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
-			"integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-resolve-all": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
-			"integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-sanitize-uri": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
-			"integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-encode": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"node_modules/micromark-util-subtokenize": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
-			"integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"micromark-util-chunked": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0",
-				"uvu": "^0.5.0"
-			}
-		},
-		"node_modules/micromark-util-symbol": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
-			"integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			]
-		},
-		"node_modules/micromark-util-types": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
-			"integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			]
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.4",
@@ -6441,14 +5831,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mri": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/ms": {
@@ -10270,17 +9652,6 @@
 				"npm": ">=2.0.0"
 			}
 		},
-		"node_modules/sade": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-			"dependencies": {
-				"mri": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -11323,31 +10694,6 @@
 			"dev": true,
 			"bin": {
 				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/uvu": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
-			"integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
-			"dependencies": {
-				"dequal": "^2.0.0",
-				"diff": "^5.0.0",
-				"kleur": "^4.0.3",
-				"sade": "^1.7.3"
-			},
-			"bin": {
-				"uvu": "bin.js"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/uvu/node_modules/kleur": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/v8-compile-cache": {
@@ -12905,14 +12251,6 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
-		"@types/debug": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-			"integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-			"requires": {
-				"@types/ms": "*"
-			}
-		},
 		"@types/graceful-fs": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -12959,11 +12297,6 @@
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
 			"integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
 			"dev": true
-		},
-		"@types/ms": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
 		},
 		"@types/node": {
 			"version": "18.11.18",
@@ -13680,21 +13013,6 @@
 				}
 			}
 		},
-		"decode-named-character-reference": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-			"integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-			"requires": {
-				"character-entities": "^2.0.0"
-			},
-			"dependencies": {
-				"character-entities": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-					"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
-				}
-			}
-		},
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -13741,21 +13059,11 @@
 			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
 			"dev": true
 		},
-		"dequal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
-		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
-		},
-		"diff": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-			"integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
 		},
 		"diff-sequences": {
 			"version": "29.3.1",
@@ -15792,9 +15100,12 @@
 			"dev": true
 		},
 		"markdown-table": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-			"integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+			"integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+			"requires": {
+				"repeat-string": "^1.0.0"
+			}
 		},
 		"marked": {
 			"version": "2.0.3",
@@ -15848,25 +15159,6 @@
 				"mdast-util-gfm-table": "^0.1.0",
 				"mdast-util-gfm-task-list-item": "^0.1.0",
 				"mdast-util-to-markdown": "^0.6.1"
-			},
-			"dependencies": {
-				"markdown-table": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-					"integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-					"requires": {
-						"repeat-string": "^1.0.0"
-					}
-				},
-				"mdast-util-gfm-table": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
-					"integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
-					"requires": {
-						"markdown-table": "^2.0.0",
-						"mdast-util-to-markdown": "~0.6.0"
-					}
-				}
 			}
 		},
 		"mdast-util-gfm-autolink-literal": {
@@ -15888,120 +15180,12 @@
 			}
 		},
 		"mdast-util-gfm-table": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.6.tgz",
-			"integrity": "sha512-uHR+fqFq3IvB3Rd4+kzXW8dmpxUhvgCQZep6KdjsLK4O6meK5dYZEayLtIxNus1XO3gfjfcIFe8a7L0HZRGgag==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+			"integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
 			"requires": {
-				"@types/mdast": "^3.0.0",
-				"markdown-table": "^3.0.0",
-				"mdast-util-from-markdown": "^1.0.0",
-				"mdast-util-to-markdown": "^1.3.0"
-			},
-			"dependencies": {
-				"longest-streak": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-					"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
-				},
-				"mdast-util-from-markdown": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
-					"integrity": "sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==",
-					"requires": {
-						"@types/mdast": "^3.0.0",
-						"@types/unist": "^2.0.0",
-						"decode-named-character-reference": "^1.0.0",
-						"mdast-util-to-string": "^3.1.0",
-						"micromark": "^3.0.0",
-						"micromark-util-decode-numeric-character-reference": "^1.0.0",
-						"micromark-util-decode-string": "^1.0.0",
-						"micromark-util-normalize-identifier": "^1.0.0",
-						"micromark-util-symbol": "^1.0.0",
-						"micromark-util-types": "^1.0.0",
-						"unist-util-stringify-position": "^3.0.0",
-						"uvu": "^0.5.0"
-					}
-				},
-				"mdast-util-to-markdown": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.4.0.tgz",
-					"integrity": "sha512-IjXARf/O8VGx/pc5SZ7syfydq1DYL9vd92orsG5U0b4GNCmAvXzu+n7sbzfIKrXwB0AVrYk3NV2kXl0AIi9LCA==",
-					"requires": {
-						"@types/mdast": "^3.0.0",
-						"@types/unist": "^2.0.0",
-						"longest-streak": "^3.0.0",
-						"mdast-util-to-string": "^3.0.0",
-						"micromark-util-decode-string": "^1.0.0",
-						"unist-util-visit": "^4.0.0",
-						"zwitch": "^2.0.0"
-					}
-				},
-				"mdast-util-to-string": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
-					"integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
-				},
-				"micromark": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz",
-					"integrity": "sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==",
-					"requires": {
-						"@types/debug": "^4.0.0",
-						"debug": "^4.0.0",
-						"decode-named-character-reference": "^1.0.0",
-						"micromark-core-commonmark": "^1.0.1",
-						"micromark-factory-space": "^1.0.0",
-						"micromark-util-character": "^1.0.0",
-						"micromark-util-chunked": "^1.0.0",
-						"micromark-util-combine-extensions": "^1.0.0",
-						"micromark-util-decode-numeric-character-reference": "^1.0.0",
-						"micromark-util-encode": "^1.0.0",
-						"micromark-util-normalize-identifier": "^1.0.0",
-						"micromark-util-resolve-all": "^1.0.0",
-						"micromark-util-sanitize-uri": "^1.0.0",
-						"micromark-util-subtokenize": "^1.0.0",
-						"micromark-util-symbol": "^1.0.0",
-						"micromark-util-types": "^1.0.1",
-						"uvu": "^0.5.0"
-					}
-				},
-				"unist-util-is": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
-					"integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
-				},
-				"unist-util-stringify-position": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
-					"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
-					"requires": {
-						"@types/unist": "^2.0.0"
-					}
-				},
-				"unist-util-visit": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.1.tgz",
-					"integrity": "sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^5.0.0",
-						"unist-util-visit-parents": "^5.1.1"
-					}
-				},
-				"unist-util-visit-parents": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.1.tgz",
-					"integrity": "sha512-gks4baapT/kNRaWxuGkl5BIhoanZo7sC/cUT/JToSRNL1dYoXRFl75d++NkjYk4TAu2uv2Px+l8guMajogeuiw==",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^5.0.0"
-					}
-				},
-				"zwitch": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-					"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
-				}
+				"markdown-table": "^2.0.0",
+				"mdast-util-to-markdown": "~0.6.0"
 			}
 		},
 		"mdast-util-gfm-task-list-item": {
@@ -16070,29 +15254,6 @@
 				"parse-entities": "^2.0.0"
 			}
 		},
-		"micromark-core-commonmark": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz",
-			"integrity": "sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==",
-			"requires": {
-				"decode-named-character-reference": "^1.0.0",
-				"micromark-factory-destination": "^1.0.0",
-				"micromark-factory-label": "^1.0.0",
-				"micromark-factory-space": "^1.0.0",
-				"micromark-factory-title": "^1.0.0",
-				"micromark-factory-whitespace": "^1.0.0",
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-chunked": "^1.0.0",
-				"micromark-util-classify-character": "^1.0.0",
-				"micromark-util-html-tag-name": "^1.0.0",
-				"micromark-util-normalize-identifier": "^1.0.0",
-				"micromark-util-resolve-all": "^1.0.0",
-				"micromark-util-subtokenize": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.1",
-				"uvu": "^0.5.0"
-			}
-		},
 		"micromark-extension-gfm": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
@@ -16142,171 +15303,6 @@
 			"requires": {
 				"micromark": "~2.11.0"
 			}
-		},
-		"micromark-factory-destination": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
-			"integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
-			"requires": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"micromark-factory-label": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
-			"integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
-			"requires": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0",
-				"uvu": "^0.5.0"
-			}
-		},
-		"micromark-factory-space": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
-			"integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
-			"requires": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"micromark-factory-title": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
-			"integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
-			"requires": {
-				"micromark-factory-space": "^1.0.0",
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0",
-				"uvu": "^0.5.0"
-			}
-		},
-		"micromark-factory-whitespace": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
-			"integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
-			"requires": {
-				"micromark-factory-space": "^1.0.0",
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"micromark-util-character": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
-			"integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
-			"requires": {
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"micromark-util-chunked": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
-			"integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
-			"requires": {
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"micromark-util-classify-character": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
-			"integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
-			"requires": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"micromark-util-combine-extensions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
-			"integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
-			"requires": {
-				"micromark-util-chunked": "^1.0.0",
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"micromark-util-decode-numeric-character-reference": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
-			"integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
-			"requires": {
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"micromark-util-decode-string": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
-			"integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
-			"requires": {
-				"decode-named-character-reference": "^1.0.0",
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-decode-numeric-character-reference": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"micromark-util-encode": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
-			"integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA=="
-		},
-		"micromark-util-html-tag-name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz",
-			"integrity": "sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA=="
-		},
-		"micromark-util-normalize-identifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
-			"integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
-			"requires": {
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"micromark-util-resolve-all": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
-			"integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
-			"requires": {
-				"micromark-util-types": "^1.0.0"
-			}
-		},
-		"micromark-util-sanitize-uri": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
-			"integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
-			"requires": {
-				"micromark-util-character": "^1.0.0",
-				"micromark-util-encode": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0"
-			}
-		},
-		"micromark-util-subtokenize": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
-			"integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
-			"requires": {
-				"micromark-util-chunked": "^1.0.0",
-				"micromark-util-symbol": "^1.0.0",
-				"micromark-util-types": "^1.0.0",
-				"uvu": "^0.5.0"
-			}
-		},
-		"micromark-util-symbol": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
-			"integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ=="
-		},
-		"micromark-util-types": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
-			"integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w=="
 		},
 		"micromatch": {
 			"version": "4.0.4",
@@ -16375,11 +15371,6 @@
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
 			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
 			"dev": true
-		},
-		"mri": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
 		},
 		"ms": {
 			"version": "2.1.2",
@@ -19140,14 +18131,6 @@
 				"tslib": "^1.9.0"
 			}
 		},
-		"sade": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-			"requires": {
-				"mri": "^1.1.0"
-			}
-		},
 		"safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -19953,24 +18936,6 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"dev": true
-		},
-		"uvu": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
-			"integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
-			"requires": {
-				"dequal": "^2.0.0",
-				"diff": "^5.0.0",
-				"kleur": "^4.0.3",
-				"sade": "^1.7.3"
-			},
-			"dependencies": {
-				"kleur": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-					"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
-				}
-			}
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	},
 	"homepage": "https://github.com/skoropadas/telegramify-markdown#readme",
 	"dependencies": {
-		"mdast-util-gfm-table": "^1.0.6",
+		"mdast-util-gfm-table": "^0.1.6",
 		"mdast-util-to-markdown": "^0.6.2",
 		"remark-gfm": "^1.0.0",
 		"remark-parse": "^9.0.0",

--- a/tests/convert.spec.js
+++ b/tests/convert.spec.js
@@ -287,6 +287,21 @@ foo = 'bar'
 
 			expect(convert(markdown, 'escape')).toBe(tgMarkdown);
 		});
+
+
+		it('should escape table', () => {
+			const markdown = `| a | b | c | d |
+| - | :- | -: | :-: |
+| e | f |
+| g | h | i | j | k |`;
+			const tgMarkdown = `\\| a \\| b  \\|  c \\|  d  \\|   \\|
+\\| \\- \\| :\\- \\| \\-: \\| :\\-: \\| \\- \\|
+\\| e \\| f  \\|    \\|     \\|   \\|
+\\| g \\| h  \\|  i \\|  j  \\| k \\|
+`;
+
+			expect(convert(markdown, 'escape')).toBe(tgMarkdown);
+		});
 	})
 
 	describe('remove unsupported tags', () => {

--- a/tests/convert.spec.js
+++ b/tests/convert.spec.js
@@ -288,7 +288,6 @@ foo = 'bar'
 			expect(convert(markdown, 'escape')).toBe(tgMarkdown);
 		});
 
-
 		it('should escape table', () => {
 			const markdown = `| a | b | c | d |
 | - | :- | -: | :-: |
@@ -314,6 +313,16 @@ foo = 'bar'
 
 		it('should remove html', () => {
 			const markdown = '<div></div>';
+			const tgMarkdown = '';
+
+			expect(convert(markdown, 'remove')).toBe(tgMarkdown);
+		});
+
+		it('should remove table', () => {
+			const markdown = `| a | b | c | d |
+| - | :- | -: | :-: |
+| e | f |
+| g | h | i | j | k |`;
 			const tgMarkdown = '';
 
 			expect(convert(markdown, 'remove')).toBe(tgMarkdown);


### PR DESCRIPTION
GFM tables need to be escaped because the `|` character is reserved in [Telegram Markdown V2](https://core.telegram.org/bots/api#markdownv2-style).