### PR TITLE
feat: add support for Telegram MarkdownV2 blockquotes

### DIFF
--- a/lib/telegramify.js
+++ b/lib/telegramify.js
@@ -129,8 +129,14 @@ const createHandlers = (definitions, unsupportedTagsStrategy) => ({
 		return escapeSymbols(text);
 	},
 
-	blockquote: (node, _parent, context) =>
-		processUnsupportedTags(defaultHandlers.blockquote(node, _parent, context), unsupportedTagsStrategy),
+	blockquote: (node, _parent, context) => {
+		// Process blockquote according to Telegram's Markdown V2 format
+		// In Telegram, blockquotes use >text format (no space after >)
+		
+		// Get the content using the default handler then format it
+		const content = defaultHandlers.blockquote(node, _parent, context);
+		return content.replace(/^> /gm, '>');
+	},
 	html: (node, _parent, context) =>
 		processUnsupportedTags(defaultHandlers.html(node, _parent, context), unsupportedTagsStrategy),
 	table: (node, _parent, context) =>

--- a/tests/convert.spec.js
+++ b/tests/convert.spec.js
@@ -272,14 +272,27 @@ foo = 'bar'
 
 		expect(convert(markdown)).toBe(tgMarkdown);
 	})
+	
+	it('Blockquote', () => {
+		const markdown = '> This is a blockquote';
+		const tgMarkdown = '>This is a blockquote\n';
+		expect(convert(markdown)).toBe(tgMarkdown);
+	});
+	
+	it('Multi-line blockquote', () => {
+		const markdown = '> Line 1\n> Line 2\n> Line 3';
+		const tgMarkdown = '>Line 1\n>Line 2\n>Line 3\n';
+		expect(convert(markdown)).toBe(tgMarkdown);
+	});
+	
+	it('Blockquote with formatting', () => {
+		const markdown = '> *Italic* and **bold** text in blockquote';
+		const tgMarkdown = '>_Italic_ and *bold* text in blockquote\n';
+		expect(convert(markdown)).toBe(tgMarkdown);
+	});
+	
 
 	describe('escape unsupported tags', () => {
-		it('should escape blockquote', () => {
-			const markdown = '> test';
-			const tgMarkdown = '\\> test\n';
-
-			expect(convert(markdown, 'escape')).toBe(tgMarkdown);
-		});
 
 		it('should escape html', () => {
 			const markdown = '<div></div>';
@@ -304,12 +317,6 @@ foo = 'bar'
 	})
 
 	describe('remove unsupported tags', () => {
-		it('should remove blockquote', () => {
-			const markdown = '> test';
-			const tgMarkdown = '';
-
-			expect(convert(markdown, 'remove')).toBe(tgMarkdown);
-		});
 
 		it('should remove html', () => {
 			const markdown = '<div></div>';


### PR DESCRIPTION
This PR adds support for Telegram's MarkdownV2 blockquotes format, where blockquotes use `>text` formatting without a space after the `>` character.

## Changes:
- Updated the blockquote handler to format blockquotes according to Telegram's MarkdownV2 specification
- Added tests for blockquote formatting with different content types
- Removed blockquotes from the "unsupported tags" category

## Testing:
All tests are passing, including the new tests for blockquote formatting.