### PR TITLE
fix: blockquote is broken #20

### DIFF
--- a/lib/telegramify.js
+++ b/lib/telegramify.js
@@ -129,8 +129,7 @@ const createHandlers = (definitions, unsupportedTagsStrategy) => ({
 		return escapeSymbols(text);
 	},
 
-	blockquote: (node, _parent, context) =>
-		processUnsupportedTags(defaultHandlers.blockquote(node, _parent, context), unsupportedTagsStrategy),
+	blockquote: (node, _parent, context) => defaultHandlers.blockquote(node, _parent, context),
 	html: (node, _parent, context) =>
 		processUnsupportedTags(defaultHandlers.html(node, _parent, context), unsupportedTagsStrategy),
 	table: (node, _parent, context) =>

--- a/tests/convert.spec.js
+++ b/tests/convert.spec.js
@@ -281,8 +281,8 @@ foo = 'bar'
 
 	describe('escape unsupported tags', () => {
 		it('should keep blockquote as supported', () => {
-			const markdown = '> test';
-			const tgMarkdown = '> test\n';
+			const markdown = '> test.';
+			const tgMarkdown = '> test\\.\n';
 
 			expect(convert(markdown, 'escape')).toBe(tgMarkdown);
 		});

--- a/tests/convert.spec.js
+++ b/tests/convert.spec.js
@@ -280,9 +280,9 @@ foo = 'bar'
 	})
 
 	describe('escape unsupported tags', () => {
-		it('should escape blockquote', () => {
+		it('should keep blockquote as supported', () => {
 			const markdown = '> test';
-			const tgMarkdown = '\\> test\n';
+			const tgMarkdown = '> test\n';
 
 			expect(convert(markdown, 'escape')).toBe(tgMarkdown);
 		});
@@ -317,9 +317,9 @@ foo = 'bar'
 	})
 
 	describe('remove unsupported tags', () => {
-		it('should remove blockquote', () => {
+		it('should keep blockquote as supported', () => {
 			const markdown = '> test';
-			const tgMarkdown = '';
+			const tgMarkdown = '> test\n';
 
 			expect(convert(markdown, 'remove')).toBe(tgMarkdown);
 		});


### PR DESCRIPTION
фикс #20. blockquotes поддерживаются телегой начиная с Bot API 7.0, не нужно их эскейпить или удалять